### PR TITLE
jessie-backports: libclc: Avoid searching the library from host machine

### DIFF
--- a/meta-jessie-backports/recipes-debian/libclc/files/fix-using-host-library.patch
+++ b/meta-jessie-backports/recipes-debian/libclc/files/fix-using-host-library.patch
@@ -1,0 +1,16 @@
+Add the path to the native sysroot directories containing the libraries,
+avoid searching the library on host machine
+
+diff --git a/configure.py b/configure.py
+index 54023c1..c8d3a9b 100755
+--- a/configure.py
++++ b/configure.py
+@@ -73,7 +73,7 @@ if llvm_int_version < 370:
+     print "libclc requires LLVM >= 3.7"
+     sys.exit(1)
+ 
+-llvm_system_libs = llvm_config(['--system-libs'])
++llvm_system_libs = "-L##STAGING_LIBDIR_NATIVE## " + llvm_config(['--system-libs'])
+ llvm_bindir = llvm_config(['--bindir'])
+ llvm_core_libs = llvm_config(['--libs', 'core', 'bitreader', 'bitwriter']) + ' ' + \
+                  llvm_system_libs + ' ' + \

--- a/meta-jessie-backports/recipes-debian/libclc/libclc_debian.bb
+++ b/meta-jessie-backports/recipes-debian/libclc/libclc_debian.bb
@@ -16,6 +16,8 @@ LIC_FILES_CHKSUM = "\
   file://LICENSE.TXT;md5=3d5e39153f76a72ef2ced27e62d33511 \
 "
 
+SRC_URI += "file://fix-using-host-library.patch"
+
 inherit autotools-brokensep
 
 DEPENDS = "python llvm-toolchain-3.8"
@@ -25,6 +27,7 @@ export YOCTO_ALTERNATE_EXE_PATH = "${STAGING_DIR_HOST}${nonarch_libdir}/llvm-3.8
 
 do_configure(){
 	cd ${S}
+	sed -i -e "s|##STAGING_LIBDIR_NATIVE##|${STAGING_LIBDIR_NATIVE}|" configure.py
 	./configure.py  --prefix=${prefix} --with-llvm-config=${STAGING_BINDIR_NATIVE}/llvm-config-3.8
 }
 


### PR DESCRIPTION
| $ llvm-config-3.8 --system-libs    //configure.py
| -lrt -ldl -ltinfo -lpthread -lz -lm
"clang++" will search these library from host machine by default,
Add option "-L${STAGING_LIBDIR_NATIVE}" to use the library in sysroot
